### PR TITLE
Rename type definitions folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nested component dir name starts with capital letter.
 ### assets/
 CSS/images/fonts — all related assets are placed there.
 
-### typedefs/
+### types/
 Put your types definitions into this dir. Put each type into one file in order to avoid having single big and poorely maintainable file where all types are defined.
 
 ### index.js


### PR DESCRIPTION
@gvidon Not sure, if this needs to be changed, but we're using `types` folder name for quite a long time.
[This doc](https://github.com/ottofeller/docs/blob/master/coding-conventions.md) references `reacto`, so maybe some clarification on that should be added there instead of this repo.